### PR TITLE
child compiler issue

### DIFF
--- a/svg-spritemap.js
+++ b/svg-spritemap.js
@@ -32,7 +32,7 @@ SVGSpritemapPlugin.prototype.apply = function(compiler) {
     var options = this.options,
         files = glob.sync(options.src, options.glob);
 
-    compiler.plugin('compilation', function(compilation) {
+    compiler.plugin('this-compilation', function(compilation) {
         compilation.plugin('optimize-chunks', function optmizeChunks(chunks) {
             if ( files.length ) {
                 // Add new chunk for spritemap


### PR DESCRIPTION
Firstly, thanks for the great plugin. Good to see one with svgo and svg4everybody options. 

I was having trouble integrating this plugin in with my webpack config and was receiving a 'Child compilation failed: Multiple assets emit to the same filename' error. I traced this back to the htm-webpack-plugin and after a bit of research found that the html-webpack-plugin uses a child compiler which likely inherits the SVG-Spritemap-Webpack-Plugin from the main compiler configuration as detailed for the AgggressiveSplittingPlugin: [https://github.com/jantimon/html-webpack-plugin/pull/670] - the solution is about halfway down. 

This simple solution can be applied to line 35 and will stop the child compilations and therefore prevent multiple assets being added across chunks.